### PR TITLE
[V0.9] Add extra cases in month_salary calculation to cover corner cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@
   - Tracks daily expenses
   - Auto currency conversion (XXX to SGD)
   - Tracks monthly recurring expenses (Included in current month's total expense if valid)
-- To-Do
   - Utilizes salary to calculate remaining spending power
+- To-Do
   - Plot monthly/yearly expense graph
   - Plot expense graph for custom time period
 - Quality of Life (QoL) items


### PR DESCRIPTION
- Add extra cases to month_salary calculation to cover corner cases

| Case | Description |
| :----: |  :-----------: |
| end_date == "" | Default case - Latest salary info |
| end_date >= current_month + end_date == current_year | Intermediate salary info (If within same year) |
| end_date > current_year | Intermediate salary info (If is in the future)