### PR TITLE
Potential fix for code scanning alert no. 6: Flask app is run in debug mode

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,6 +3,8 @@ from web.routes import bp as main_bp
 
 app = Flask(__name__)
 app.register_blueprint(main_bp)
+import os
 
 if __name__ == "__main__":
-    app.run(debug=True)
+    debug_mode = os.getenv("FLASK_DEBUG", "False").lower() in ("true", "1", "t")
+    app.run(debug=debug_mode)


### PR DESCRIPTION
Potential fix for [https://github.com/chuanseng-ng/Finance_Track_Web/security/code-scanning/6](https://github.com/chuanseng-ng/Finance_Track_Web/security/code-scanning/6)

To fix the problem, we need to ensure that the Flask application does not run in debug mode in a production environment. The best way to achieve this is to control the debug mode setting based on an environment variable. This way, we can enable debug mode during development and disable it in production.

1. Import the `os` module to access environment variables.
2. Use an environment variable (e.g., `FLASK_DEBUG`) to determine whether to run the app in debug mode.
3. Update the `app.run` call to use the value of this environment variable.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
