### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request: {}
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/chuanseng-ng/Finance_Track_Web/security/code-scanning/13](https://github.com/chuanseng-ng/Finance_Track_Web/security/code-scanning/13)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow is for linting and does not require write access, we will set `contents: read` as the minimal permission required. This ensures that the workflow has only the necessary permissions to perform its tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
